### PR TITLE
Fix bug resulting in data corruption

### DIFF
--- a/eisbuk-admin/src/components/slots/SlotListByDay/Slot.js
+++ b/eisbuk-admin/src/components/slots/SlotListByDay/Slot.js
@@ -48,7 +48,6 @@ export default ({
       if (subscribedDuration === duration) {
         onUnsubscribe(data);
       } else {
-        onUnsubscribe(data);
         onSubscribe({ ...data, duration });
       }
     } else {


### PR DESCRIPTION
The subscribe action implicitly unsubscribes from any previously subscriptions on the same slot.
The explicit unsubscription that this commit removes was executed in an asynchronous fashion,
and the ordering of subscribe/unsubscribe was determined randomly.
This caused the unsubscribe to sometimes run last, removing the just subscribed slot.