### PR TITLE
Fixes #91 : User can select a subset of slots from copied week

### DIFF
--- a/eisbuk-admin/package.json
+++ b/eisbuk-admin/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
+    "clsx": "^1.1.1",
     "firebase": "^8.2.3",
     "firebase-tools": "^9.1.1",
     "formik": "^2.1.5",

--- a/eisbuk-admin/src/components/slots/SlotListByDay/Slot.js
+++ b/eisbuk-admin/src/components/slots/SlotListByDay/Slot.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
+import clsx from "clsx";
 import {
   Button,
   ButtonGroup,
@@ -26,6 +27,7 @@ export default ({
   data,
   onDelete,
   deleted,
+  selected,
   onSubscribe,
   onUnsubscribe,
   subscribedSlots,
@@ -57,7 +59,11 @@ export default ({
   return (
     <>
       {!deleted && (
-        <Card className={classes.root} raised={isSubscribed} variant="outlined">
+        <Card
+          className={clsx(classes.root, { [classes.selected]: selected })}
+          raised={isSubscribed}
+          variant="outlined"
+        >
           <CardContent className={classes.wrapper}>
             <Box p={1} flexShrink={0} className={classes.slotTime}>
               <Typography
@@ -296,5 +302,8 @@ const useStyles = makeStyles((theme) => ({
   },
   "&.MuiPaper-elevation8": {
     border: "2px solid red",
+  },
+  selected: {
+    backgroundColor: theme.palette.warning.light,
   },
 }));

--- a/eisbuk-admin/src/components/slots/SlotListByDay/SlotsDay.js
+++ b/eisbuk-admin/src/components/slots/SlotListByDay/SlotsDay.js
@@ -21,6 +21,7 @@ import {
   deleteSlotFromClipboard,
   addSlotToClipboard,
 } from "../../../store/actions/actions";
+import { calendarDaySelector } from "../../../store/selectors";
 import { shiftSlotsDay } from "../../../data/slotutils";
 import LuxonUtils from "@date-io/luxon";
 import { DateTime } from "luxon";
@@ -47,17 +48,19 @@ const SlotsDay = ({
   const [deletedSlots, setDeletedSlots] = useState({});
   const dispatch = useDispatch();
   const auth = useSelector((state) => state.firebase.auth);
-
+  const currentWeek = useSelector(calendarDaySelector).startOf("week");
   const luxonDay = luxon.parse(day, "yyyy-LL-dd");
   const dateStr = luxonDay.toFormat("EEEE d MMMM", { locale: "it-IT" });
-
   const copiedWeek = useSelector((state) => state.copyPaste.week) || {};
   const copiedWeekSlots = copiedWeek.slots
     ? copiedWeek.slots.map((slot) => slot.id)
     : [];
 
   const checkSelected = (id) => copiedWeekSlots.includes(id);
-  const canClickSlots = enableEdit && copiedWeekSlots.length > 0;
+  const canClickSlots =
+    enableEdit &&
+    copiedWeekSlots.length > 0 &&
+    copiedWeek.weekStart.equals(currentWeek);
   const extendedOnDelete =
     onDelete && enableEdit
       ? (slot) => {

--- a/eisbuk-admin/src/components/slots/SlotListByDay/SlotsDay.js
+++ b/eisbuk-admin/src/components/slots/SlotListByDay/SlotsDay.js
@@ -15,7 +15,12 @@ import {
   Assignment as AssignmentIcon,
 } from "@material-ui/icons";
 import Slot from "./Slot";
-import { copySlotDay, createSlots } from "../../../store/actions/actions";
+import {
+  copySlotDay,
+  createSlots,
+  deleteSlotFromClipboard,
+  addSlotToClipboard,
+} from "../../../store/actions/actions";
 import { shiftSlotsDay } from "../../../data/slotutils";
 import LuxonUtils from "@date-io/luxon";
 import { DateTime } from "luxon";
@@ -50,6 +55,9 @@ const SlotsDay = ({
   const copiedWeekSlots = copiedWeek.slots
     ? copiedWeek.slots.map((slot) => slot.id)
     : [];
+
+  const checkSelected = (id) => copiedWeekSlots.includes(id);
+  const canClickSlots = enableEdit && copiedWeekSlots.length > 0;
   const extendedOnDelete =
     onDelete && enableEdit
       ? (slot) => {
@@ -119,9 +127,13 @@ const SlotsDay = ({
               <Grid
                 key={slot.id}
                 className={
-                  copiedWeekSlots.includes(slot.id) && enableEdit
-                    ? classes.selected
-                    : classes.unselected
+                  canClickSlots ? classes.clickable : classes.unclickable
+                }
+                onClick={() =>
+                  canClickSlots &&
+                  (checkSelected(slot.id)
+                    ? dispatch(deleteSlotFromClipboard(slot.id))
+                    : dispatch(addSlotToClipboard(slot)))
                 }
                 item
                 xs={12}
@@ -130,6 +142,7 @@ const SlotsDay = ({
                 xl={!isCustomer ? 2 : 3}
               >
                 <Slot
+                  selected={checkSelected(slot.id)}
                   data={slot}
                   key={slot.id}
                   deleted={!!deletedSlots[slot.id]}
@@ -190,10 +203,10 @@ const useStyles = makeStyles((theme) => ({
   dateButtons: {
     "flex-grow": 0,
   },
-  selected: {
-    backgroundColor: theme.palette.warning.main,
+  clickable: {
+    cursor: "pointer",
   },
-  unselected: {
-    backgroundColor: theme.palette.grey[100],
+  unclickable: {
+    cursor: "auto",
   },
 }));

--- a/eisbuk-admin/src/config/envInfoEnv.js
+++ b/eisbuk-admin/src/config/envInfoEnv.js
@@ -6,4 +6,4 @@ export const EISBUK_SITE = process.env.EISBUK_SITE;
 // So we came up with this ugly hack: a string in this file that has no impact on the code,
 // and can be changed by the startup script.
 // This file is included in .gitignore for convenience
-// Date this was last changed: Wed  7 Jul 08:38:24 EET 2021
+// Date this was last changed: Wed 14 Jul 08:51:22 EET 2021

--- a/eisbuk-admin/src/config/envInfoEnv.js
+++ b/eisbuk-admin/src/config/envInfoEnv.js
@@ -6,4 +6,4 @@ export const EISBUK_SITE = process.env.EISBUK_SITE;
 // So we came up with this ugly hack: a string in this file that has no impact on the code,
 // and can be changed by the startup script.
 // This file is included in .gitignore for convenience
-// Date this was last changed: Sun  4 Jul 23:21:27 EET 2021
+// Date this was last changed: Wed  7 Jul 08:38:24 EET 2021

--- a/eisbuk-admin/src/containers/SlotsPageContainer.js
+++ b/eisbuk-admin/src/containers/SlotsPageContainer.js
@@ -131,8 +131,7 @@ export default ({
             tooltip="Incolla settimana"
             disabled={
               !weekToPaste.weekStart || // there's nothing to paste
-              +weekToPaste.weekStart === +currentDate || // don't paste over the same week we copied
-              slotsArray.length !== 0 // Only let users paste onto an empty week
+              +weekToPaste.weekStart === +currentDate // don't paste over the same week we copied
             }
           >
             <AssignmentIcon />

--- a/eisbuk-admin/src/store/actions/action-types.js
+++ b/eisbuk-admin/src/store/actions/action-types.js
@@ -6,6 +6,8 @@ export const CHANGE_DAY = "@@Eisbuk/CHANGE_DAY";
 
 export const COPY_SLOT_DAY = "@@Eisbuk/COPY_SLOT_DAY";
 export const COPY_SLOT_WEEK = "@@Eisbuk/COPY_SLOT_WEEK";
+export const DELETE_SLOT_FROM_CLIPBOARD = "@@Eisbuk/DELETE_SLOT_FROM_CLIPBOARD";
+export const ADD_SLOT_TO_CLIPBOARD = "@@Eisbuk/ADD_SLOT_TO_CLIPBOARD";
 
 export const SET_SLOT_TIME = "@@Eisbuk/SET_SLOT_TIME";
 

--- a/eisbuk-admin/src/store/actions/actions.js
+++ b/eisbuk-admin/src/store/actions/actions.js
@@ -11,6 +11,8 @@ import {
   COPY_SLOT_DAY,
   COPY_SLOT_WEEK,
   SET_SLOT_TIME,
+  DELETE_SLOT_FROM_CLIPBOARD,
+  ADD_SLOT_TO_CLIPBOARD,
 } from "./action-types";
 import { ORGANIZATION } from "../../config/envInfo";
 
@@ -392,4 +394,14 @@ export const copySlotDay = (slotDay) => ({
 export const copySlotWeek = (slotWeek) => ({
   type: COPY_SLOT_WEEK,
   payload: slotWeek,
+});
+
+export const deleteSlotFromClipboard = (id) => ({
+  type: DELETE_SLOT_FROM_CLIPBOARD,
+  payload: id,
+});
+
+export const addSlotToClipboard = (id) => ({
+  type: ADD_SLOT_TO_CLIPBOARD,
+  payload: id,
 });

--- a/eisbuk-admin/src/store/reducers/copyPasteReducer.js
+++ b/eisbuk-admin/src/store/reducers/copyPasteReducer.js
@@ -1,4 +1,9 @@
-import { COPY_SLOT_DAY, COPY_SLOT_WEEK } from "../actions/action-types";
+import {
+  COPY_SLOT_DAY,
+  COPY_SLOT_WEEK,
+  DELETE_SLOT_FROM_CLIPBOARD,
+  ADD_SLOT_TO_CLIPBOARD,
+} from "../actions/action-types";
 
 const defaultState = {
   day: null,
@@ -11,6 +16,19 @@ export const copyPasteReducer = (state = defaultState, action) => {
       return { ...state, day: { ...action.payload } };
     case COPY_SLOT_WEEK:
       return { ...state, week: { ...action.payload } };
+    case DELETE_SLOT_FROM_CLIPBOARD:
+      return {
+        ...state,
+        week: {
+          ...state.week,
+          slots: state.week.slots.filter((slot) => slot.id !== action.payload),
+        },
+      };
+    case ADD_SLOT_TO_CLIPBOARD:
+      return {
+        ...state,
+        week: { ...state.week, slots: state.week.slots.concat(action.payload) },
+      };
     default:
       return state;
   }

--- a/eisbuk-admin/yarn.lock
+++ b/eisbuk-admin/yarn.lock
@@ -6248,7 +6248,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clsx@^1.0.2, clsx@^1.0.4, clsx@^1.1.0:
+clsx@^1.0.2, clsx@^1.0.4, clsx@^1.1.0, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==


### PR DESCRIPTION
selectable copypaste functionality:
- implemented two new actions for adding ond deleting from copyWeekSlots
- selecting a slot highlights and deselecting de-highlights
- slots can be pasted into non-empty weeks